### PR TITLE
chore: Remove ghostty split keybindings

### DIFF
--- a/conf/ghostty/config
+++ b/conf/ghostty/config
@@ -41,6 +41,10 @@
 # # which is explained in the docs for that config option.
 # # Just for example:
 # resize-overlay-duration = 4s 200ms
+#
+# Keybinding requires the following syntax 
+# keybind = ctrl+a>f=toggle_split_zoom 
+
 
 shell-integration = zsh
 font-family = JetBrains Mono


### PR DESCRIPTION
Since we are back to defaulting to tmux, we don't need Ghostty keybindings to conflict with tmux keybindings. 